### PR TITLE
use AsRef<str> instead of String

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iwlib"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Sibi Prabakaran <sibi@psibi.in>"]
 edition = "2018"
 readme = "README.md"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,6 +1,5 @@
 use iwlib::*;
 
 fn main() {
-    let wireless_info = get_wireless_info("wlp0s20f3".to_string());
-    println!("Wireless info: {:?}", wireless_info);
+    println!("Wireless info: {:?}", get_wireless_info("wlp0s20f3"));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,8 @@ pub struct WirelessInfo {
 /// use iwlib::*;
 /// let wireless_info = get_wireless_info("wlan0".to_string());
 /// ```
-pub fn get_wireless_info(interface: String) -> Option<WirelessInfo> {
-    let interface_name = CString::new(interface).unwrap();
+pub fn get_wireless_info(interface: impl AsRef<str>) -> Option<WirelessInfo> {
+    let interface_name = CString::new(interface.as_ref()).unwrap();
     let mut config: wireless_config = Default::default();
     let mut statistics: iw_statistics = Default::default();
     let mut range: iw_range = Default::default();
@@ -77,8 +77,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn it_does_not_crash() {
-        let wireless_info = get_wireless_info("wlp0s20f3".to_string());
-        println!("Wireless info: {:?}", wireless_info);
+    fn it_does_not_crash_string() {
+        println!(
+            "Wireless info: {:?}",
+            get_wireless_info("wlp0s20f3".to_string())
+        );
+    }
+
+    #[test]
+    fn it_does_not_crash_str() {
+        println!("Wireless info: {:?}", get_wireless_info("wlp0s20f3"));
     }
 }


### PR DESCRIPTION
This change swaps out `String` for `AsRef<str>` in the `get_wireless_info()` function. This makes it much easier for users of this crate to use it.

For example:

```rust
get_wireless_info("just a &str works");
get_wireless_info("but a String works too".to_string());
```